### PR TITLE
adds run.developer role to service account

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -50,9 +50,11 @@ resource "google_project_iam_member" "legacy-build" {
   role    = "roles/container.developer"
   member  = "serviceAccount:1016006425732@cloudbuild.gserviceaccount.com"
 }
+
 resource "google_project_iam_member" "build" {
+  for_each = toset( ["roles/container.developer", "roles/run.develper"] )
   project = module.slim_project.project_id
-  role    = "roles/container.developer"
+  role    = each.key
   member  = "serviceAccount:226821549783@cloudbuild.gserviceaccount.com"
 }
 


### PR DESCRIPTION
## Ändring
Adds run.developer role to service account.

## Skäl till ändring
Ändringen görs för att ge  cloudbuild i CI/CD permissions att deploya servicesar till bh-slim-test för att kunna automatisera
deploy steget.

Eventuellt behövs även "iam.serviceAccountUser" men vi testar utan först för att inte ge fler roller/permissions än nödvändigt.

## Osäkerheter
Skapade en 'for_each' som jag hoppas att jag förstått rätt. 

