### PR TITLE
Give legacy build service account access to Github token secret

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -1,6 +1,7 @@
 locals {
   env = "prod"
   slim_project_id = "bh-slim-test"
+  cicd_project_id = "bh-cicd"
   host_network = "bghprod"
   slim_network = "bhtest-europe-north1"
   cloudrun_network = "bhtest-cr-europe-north1"
@@ -56,6 +57,21 @@ resource "google_project_iam_member" "build" {
   project = module.slim_project.project_id
   role    = each.key
   member  = "serviceAccount:226821549783@cloudbuild.gserviceaccount.com"
+}
+
+data "google_iam_policy" "github-nuget-secret-access" {
+  binding {
+    role = "roles/secretmanager.secretAccessor"
+    members = [
+      "serviceAccount:1016006425732@cloudbuild.gserviceaccount.com"
+    ]
+  }
+}
+
+resource "google_secret_manager_secret_iam_policy" "github-nuget-secret-policy" {
+  project = local.cicd_project_id
+  secret_id = "projects/${locals.cicd_project_id}/secrets/github-serviceaccount-nuget-password"
+  policy_data = data.google_iam_policy.github-nuget-secret-access
 }
 
 module "slim_gke" {

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -59,19 +59,13 @@ resource "google_project_iam_member" "build" {
   member  = "serviceAccount:226821549783@cloudbuild.gserviceaccount.com"
 }
 
-data "google_iam_policy" "github-nuget-secret-access" {
-  binding {
-    role = "roles/secretmanager.secretAccessor"
-    members = [
-      "serviceAccount:1016006425732@cloudbuild.gserviceaccount.com"
-    ]
-  }
-}
-
-resource "google_secret_manager_secret_iam_policy" "github-nuget-secret-policy" {
+resource "google_secret_manager_secret_iam_binding" "github-nuget-secret-access" {
   project = local.cicd_project_id
-  secret_id = "projects/${locals.cicd_project_id}/secrets/github-serviceaccount-nuget-password"
-  policy_data = data.google_iam_policy.github-nuget-secret-access
+  secret_id = "projects/${local.cicd_project_id}/secrets/github-serviceaccount-nuget-password"
+  role = "roles/secretmanager.secretAccessor"
+  members = [
+      "serviceAccount:1016006425732@cloudbuild.gserviceaccount.com",
+  ]
 }
 
 module "slim_gke" {

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -1,6 +1,7 @@
 locals {
   env = "prod"
   slim_project_id = "bh-slim-prod"
+  cicd_project_id = "bh-cicd"
   host_network = "bghprod"
   slim_network = "bhprod-europe-north1"
   cloudrun_network = "bhprod-cr-europe-north1"

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -58,6 +58,15 @@ resource "google_project_iam_member" "build" {
   member  = "serviceAccount:226821549783@cloudbuild.gserviceaccount.com"
 }
 
+resource "google_secret_manager_secret_iam_binding" "github-nuget-secret-access" {
+  project = local.cicd_project_id
+  secret_id = "projects/${local.cicd_project_id}/secrets/github-serviceaccount-nuget-password"
+  role = "roles/secretmanager.secretAccessor"
+  members = [
+      "serviceAccount:1016006425732@cloudbuild.gserviceaccount.com",
+  ]
+}
+
 module "slim_gke" {
   source  = "terraform-google-modules/kubernetes-engine/google"
   version = "25.0.0"


### PR DESCRIPTION
Gives the cloudbuild service account in `bgh-network-production` access to the secret in `bh-cicd` that contains the Github access token.

![image](https://github.com/BygghemmaIT/gcp-infrastructure-terraform/assets/98592031/6faa184f-dd57-436e-ab7e-509ae2ef8ab7)
